### PR TITLE
generateClassName() to support pivot tables

### DIFF
--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -62,7 +62,7 @@ class Iseed {
 	 */
 	protected function generateClassName($table)
 	{
-		return ucfirst($table) . 'TableSeeder';
+		return ucfirst(camel_case($table)) . 'TableSeeder';
 	}
 
 	/**


### PR DESCRIPTION
Pivot tables require an underscore. This removes that issue and replaces it with a camelCase name, that we then ucfirst to make it pretty.
