### PR TITLE
generateClassName by exploding _ on table name

### DIFF
--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -106,7 +106,12 @@ class Iseed {
 	 */
 	public function generateClassName($table)
 	{
-		return ucfirst($table) . 'TableSeeder';
+		$tableString = '';
+		$tableName = explode('_', $table);
+		foreach($tableName as $tableNameExploded) {
+			$tableString .= ucfirst($tableNameExploded);
+		}
+		return ucfirst($tableString) . 'TableSeeder';
 	}
 
 	/**


### PR DESCRIPTION
In order to avoid Laravel from thinking that the Class just created is in a subfolder.
This happen for all relational tables.
