### PR TITLE
Allow custom templates

### DIFF
--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -223,7 +223,16 @@ class Iseed {
 
         $content = $this->files->get($databaseSeederPath);
         if(strpos($content, "\$this->call('{$className}')")===false)
-			$content = preg_replace("/(run\(\).+?)}/us", "$1\t\$this->call('{$className}');\n\t}", $content);
+        {
+        	if(strpos($content, '#iseed_start') && strpos($content, '#iseed_end'))
+        	{
+        		$content = preg_replace("/(\#iseed_start.+?)\#iseed_end/us", "$1\$this->call('{$className}');\n\t\t#iseed_end", $content);
+        	}
+        	else
+        	{
+        		$content = preg_replace("/(run\(\).+?)}/us", "$1\t\$this->call('{$className}');\n\t}", $content);
+        	}
+        }
 
         return $this->files->put($databaseSeederPath, $content) !== false;
         return false;

--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -212,6 +212,22 @@ class Iseed {
 		return $content;
 	}
 
+ 	/**
+    * Cleans the iSeed section
+    * @return bool
+    */
+	public function cleanSection()
+	{
+		$databaseSeederPath = app_path() . \Config::get('iseed::path') . '/DatabaseSeeder.php';
+
+		$content = $this->files->get($databaseSeederPath);
+
+		$content = preg_replace("/(\#iseed_start.+?)\#iseed_end/us", "#iseed_start\n\t\t#iseed_end", $content);
+
+		return $this->files->put($databaseSeederPath, $content) !== false;
+        return false;
+	}
+
     /**
     * Updates the DatabaseSeeder file's run method (kudoz to: https://github.com/JeffreyWay/Laravel-4-Generators)
     * @param  string  $className

--- a/src/Orangehill/Iseed/IseedCommand.php
+++ b/src/Orangehill/Iseed/IseedCommand.php
@@ -37,6 +37,11 @@ class IseedCommand extends Command {
 	 */
 	public function fire()
 	{
+		if($this->option('clean'))
+		{
+			app('iseed')->cleanSection();
+		}
+
 		$this->printResult(app('iseed')->generateSeed($this->argument('table')), $this->argument('table'));
 	}
 
@@ -49,6 +54,18 @@ class IseedCommand extends Command {
 	{
 		return array(
 			array('table', InputArgument::REQUIRED, 'table name'),
+		);
+	}
+
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return array(
+			array('clean', null, InputOption::VALUE_NONE, 'clean iseed section', null),
 		);
 	}
 


### PR DESCRIPTION
I've been having a few issues running iseed seeders in certain positions.

Firstly, I run a script to make sure seeding can't happen on production db (this could end badly). However I seed seems to not support this due to the finishing `}` tag.

I.e. 

	public function run()
	{
		Eloquent::unguard();

		if(App::environment() == "local")
		{
			throw new \Exception('Only run this from production');
		}

		$this->call('CountriesSeeder');
	}

After running `php artisan iseed groups` this ends up like:

	public function run()
	{
		Eloquent::unguard();

		if(App::environment() == "local")
		{
			throw new \Exception('Only run this from production');
			$this->call('GroupsTableSeeder');
	}

        $this->call('CountriesSeeder');
	}

Also I don't have the ability to run my custom `Users` seeder after the Groups. Ie.

	public function run()
	{
		Eloquent::unguard();

		$this->call('UsersSeeder');
	}

Ends up like:

	public function run()
	{
		Eloquent::unguard();

		$this->call('UsersSeeder');
		$this->call('GroupsTableSeeder');
	}

Therefore I ended up using `#iseed_start` and `#iseed_end` to point out where certain seeders should go.

	public function run()
	{
		Eloquent::unguard();

		if(App::environment() == "local")
		{
			throw new \Exception('Only run this from production');
		}

		$this->call('CountriesSeeder');

		#iseed_start
		#iseed_end

		$this->call('UsersSeeder');
	}

After `php artisan iseed groups` ends up:

	public function run()
	{
		Eloquent::unguard();

		if(App::environment() == "local")
		{
			throw new \Exception('Only run this from production');
		}

		$this->call('CountriesSeeder');

		#iseed_start
		$this->call('GroupsTableSeeder');
		#iseed_end

		$this->call('UsersSeeder');
	}

Perfect.