### PR TITLE
Possibility to turn off indexing for seeds

### DIFF
--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -59,7 +59,7 @@ class Iseed
      * @return bool
      * @throws Orangehill\Iseed\TableNotFoundException
      */
-    public function generateSeed($table, $database = null, $max = 0, $exclude = null, $prerunEvent = null, $postrunEvent = null, $dumpAuto = true)
+    public function generateSeed($table, $database = null, $max = 0, $exclude = null, $prerunEvent = null, $postrunEvent = null, $dumpAuto = true, $indexed = true)
     {
         if (!$database) {
             $database = config('database.default');
@@ -98,7 +98,8 @@ class Iseed
             $dataArray,
             null,
             $prerunEvent,
-            $postrunEvent
+            $postrunEvent,
+            $indexed
         );
 
         // Save a populated stub
@@ -211,7 +212,7 @@ class Iseed
      * @param  string   $postunEvent
      * @return string
      */
-    public function populateStub($class, $stub, $table, $data, $chunkSize = null, $prerunEvent = null, $postrunEvent = null)
+    public function populateStub($class, $stub, $table, $data, $chunkSize = null, $prerunEvent = null, $postrunEvent = null, $indexed = true)
     {
         $chunkSize = $chunkSize ?: config('iseed::config.chunk_size');
         $inserts = '';
@@ -222,7 +223,7 @@ class Iseed
             $inserts .= sprintf(
                 "\DB::table('%s')->insert(%s);",
                 $table,
-                $this->prettifyArray($chunk)
+                $this->prettifyArray($chunk, $indexed)
             );
         }
 
@@ -289,9 +290,11 @@ class Iseed
      * @param  array  $array
      * @return string
      */
-    protected function prettifyArray($array)
+    protected function prettifyArray($array, $indexed = true)
     {
-        $content = var_export($array, true);
+        $content = ($indexed)
+            ? var_export($array, true)
+            : preg_replace("/[0-9]+ \=\>/i", '', var_export($array, true));
 
         $lines = explode("\n", $content);
 

--- a/src/Orangehill/Iseed/IseedCommand.php
+++ b/src/Orangehill/Iseed/IseedCommand.php
@@ -50,6 +50,7 @@ class IseedCommand extends Command
         $prerunEvents = explode(",", $this->option('prerun'));
         $postrunEvents = explode(",", $this->option('postrun'));
         $dumpAuto = intval($this->option('dumpauto'));
+        $indexed = boolval($this->option('indexed'));
 
         if ($chunkSize < 1) {
             $chunkSize = null;
@@ -81,7 +82,8 @@ class IseedCommand extends Command
                         $exclude,
                         $prerunEvent,
                         $postrunEvent,
-                        $dumpAuto
+                        $dumpAuto,
+                        $indexed
                     ),
                     $table
                 );
@@ -98,7 +100,8 @@ class IseedCommand extends Command
                         $exclude,
                         $prerunEvent,
                         $postrunEvent,
-                        $dumpAuto
+                        $dumpAuto,
+                        $indexed
                     ),
                     $table
                 );
@@ -136,6 +139,7 @@ class IseedCommand extends Command
             array('prerun', null, InputOption::VALUE_OPTIONAL, 'prerun event name', null),
             array('postrun', null, InputOption::VALUE_OPTIONAL, 'postrun event name', null),
             array('dumpauto', null, InputOption::VALUE_OPTIONAL, 'run composer dump-autoload', true),
+            array('indexed', null, InputOption::VALUE_OPTIONAL, 'index items in the seed', true),
         );
     }
 


### PR DESCRIPTION
By using --indexed=0 the seed can be generated as a non-indexed array.
The usage for this is when you need to merge two seed files.