### PR TITLE
Allow user to explicitly set the class name and file name to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ php artisan iseed my_table
 php artisan iseed my_table,another_table
 ```
 
+### [table_name:class_name]
+Optionally also specify the parameter which defines the class name and file name that will be used for seed creation.
+This is useful if you want to create an additional seeder for a table that already has a seed existing at MyTableSeeder, et al.
+
+Examples:
+```
+php artisan iseed my_table:NewMyTableSeeder
+```
+```
+php artisan iseed my_table:NewMyTableSeeder,another_table:NewAnotherTableSeeder
+```
+
 ### force
 Optional parameter which is used to automatically overwrite any existing seeds for desired tables
 

--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -59,7 +59,7 @@ class Iseed
      * @return bool
      * @throws Orangehill\Iseed\TableNotFoundException
      */
-    public function generateSeed($table, $database = null, $max = 0, $exclude = null, $prerunEvent = null, $postrunEvent = null, $dumpAuto = true, $indexed = true, $orderBy = null, $direction = 'ASC')
+    public function generateSeed($table, $class, $database = null, $max = 0, $exclude = null, $prerunEvent = null, $postrunEvent = null, $dumpAuto = true, $indexed = true, $orderBy = null, $direction = 'ASC')
     {
         if (!$database) {
             $database = config('database.default');
@@ -79,7 +79,7 @@ class Iseed
         $dataArray = $this->repackSeedData($data);
 
         // Generate class name
-        $className = $this->generateClassName($table);
+        $className = $this->generateClassName($table, $class);
 
         // Get template for a seed file contents
         $stub = $this->readStubFile($this->getStubPath() . '/seed.stub');
@@ -186,8 +186,11 @@ class Iseed
      * @param  string  $table
      * @return string
      */
-    public function generateClassName($table)
+    public function generateClassName($table, $class=null)
     {
+        if ($class)
+            return $class;
+
         $tableString = '';
         $tableName = explode('_', $table);
         foreach ($tableName as $tableNameExploded) {

--- a/tests/IseedTest.php
+++ b/tests/IseedTest.php
@@ -2102,7 +2102,7 @@ class IseedTest extends PHPUnit_Framework_TestCase
     {
         $hasTable = m::mock('Orangehill\Iseed\Iseed[hasTable]')->makePartial();
         $hasTable->shouldReceive('hasTable')->once()->andReturn(false);
-        $hasTable->generateSeed('nonexisting', 'database', 'numOfRows');
+        $hasTable->generateSeed('nonexisting', null, 'database', 'numOfRows');
     }
 
     public function testRepacksSeedData()
@@ -2150,6 +2150,6 @@ class IseedTest extends PHPUnit_Framework_TestCase
         $mocked->shouldReceive('populateStub')->once()->andReturn('populatedStub');
         $mocked->shouldReceive('updateDatabaseSeederRunMethod')->once()->with('ClassName')->andReturn(true);
         $composer->shouldReceive('dumpAutoloads')->once();
-        $mocked->generateSeed('tablename', 'database', 'numOfRows');
+        $mocked->generateSeed('tablename', null, 'database', 'numOfRows');
     }
 }


### PR DESCRIPTION
`php artisan iseed things` will automatically generate the file ThingsTableSeeder.php containing a class named ThingsTableSeeder. In some cases, user may have an existing ThingsTableSeeder.php file and/or ThingsTableSeeder class which they do not want to overwrite (for example, when expanding upon an existing package that runs it's own seeders upon install - but user wants to add rows to that table).

This commit allows user to explicitly specify the file/class name, rather than it being generated automatically from the table name.

Syntax: `php artisan iseed things:AdditionalThingsTableSeeder` will create AdditionalThingsTableSeeder.php containing the class AdditionalThingsTableSeeder. CSV support remains intact: `php artisan iseed things_one:AdditionalThingsOneTableSeeder,things_two:AdditionalThingsTwoTableSeeder` works as expected