### PR TITLE
Files can be created with a namespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ Example:
 artisan iseed users --noindex
 ```
 
+### namespace
+By using --namespace the seed can be generated with a namespace.
+
+Example:
+```
+artisan iseed users --namespace=Seeds\Demo
+```
 ## Usage
 
 To generate a seed file for your users table simply call: `\Iseed::generateSeed('users', 'connectionName', 'numOfRows');`. `connectionName` and `numOfRows` are not required arguments. 

--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -59,7 +59,7 @@ class Iseed
      * @return bool
      * @throws Orangehill\Iseed\TableNotFoundException
      */
-    public function generateSeed($table, $database = null, $max = 0, $exclude = null, $prerunEvent = null, $postrunEvent = null, $dumpAuto = true, $indexed = true, $orderBy = null, $direction = 'ASC')
+    public function generateSeed($table, $database = null, $max = 0, $exclude = null, $prerunEvent = null, $postrunEvent = null, $dumpAuto = true, $indexed = true, $orderBy = null, $direction = 'ASC', $namespace = null)
     {
         if (!$database) {
             $database = config('database.default');
@@ -99,7 +99,8 @@ class Iseed
             null,
             $prerunEvent,
             $postrunEvent,
-            $indexed
+            $indexed,
+            $namespace
         );
 
         // Save a populated stub
@@ -216,7 +217,7 @@ class Iseed
      * @param  string   $postunEvent
      * @return string
      */
-    public function populateStub($class, $stub, $table, $data, $chunkSize = null, $prerunEvent = null, $postrunEvent = null, $indexed = true)
+    public function populateStub($class, $stub, $table, $data, $chunkSize = null, $prerunEvent = null, $postrunEvent = null, $indexed = true, $namespace = null)
     {
         $chunkSize = $chunkSize ?: config('iseed::config.chunk_size');
         $inserts = '';
@@ -231,7 +232,10 @@ class Iseed
             );
         }
 
+        $namespace = $namespace ? "\nnamespace $namespace;\n" : '';
+
         $stub = str_replace('{{class}}', $class, $stub);
+        $stub = str_replace('{{namespace}}', $namespace, $stub);
 
         $prerunEventInsert = '';
         if ($prerunEvent) {

--- a/src/Orangehill/Iseed/IseedCommand.php
+++ b/src/Orangehill/Iseed/IseedCommand.php
@@ -62,6 +62,7 @@ class IseedCommand extends Command
         $dumpAuto = intval($this->option('dumpauto'));
         $indexed = !$this->option('noindex');
         $orderBy = $this->option('orderby');
+        $namespace = $this->option('namespace');
         $direction = $this->option('direction');
 
         if ($chunkSize < 1) {
@@ -97,7 +98,9 @@ class IseedCommand extends Command
                         $dumpAuto,
                         $indexed,
                         $orderBy,
-                        $direction
+                        $direction,
+                        $namespace
+
                     ),
                     $table
                 );
@@ -115,7 +118,10 @@ class IseedCommand extends Command
                         $prerunEvent,
                         $postrunEvent,
                         $dumpAuto,
-                        $indexed
+                        $indexed,
+                        null,
+                        null,
+                        $namespace
                     ),
                     $table
                 );
@@ -156,6 +162,7 @@ class IseedCommand extends Command
             array('noindex', null, InputOption::VALUE_NONE, 'no indexing in the seed', null),
             array('orderby', null, InputOption::VALUE_OPTIONAL, 'orderby desc by column', null),
             array('direction', null, InputOption::VALUE_OPTIONAL, 'orderby direction', null),
+            array('namespace', null, InputOption::VALUE_OPTIONAL, 'namespace of the files', null),
         );
     }
 

--- a/src/Orangehill/Iseed/Stubs/seed.stub
+++ b/src/Orangehill/Iseed/Stubs/seed.stub
@@ -1,5 +1,5 @@
 <?php
-
+{{namespace}}
 use Illuminate\Database\Seeder;
 
 class {{class}} extends Seeder

--- a/tests/IseedTest.php
+++ b/tests/IseedTest.php
@@ -34,10 +34,38 @@ class IseedTest extends PHPUnit_Framework_TestCase
         $testStubs = array(
             'blank' => array(
                 'content' => $this->readStubFile(static::$testStubsDir . '/seed_blank.stub'),
+                'namespace' => null,
                 'data' => array(),
             ),
             'entries_5' => array(
                 'content' => $this->readStubFile(static::$testStubsDir . '/seed_5.stub'),
+                'namespace' => null,
+                'data' => array(
+                    array(
+                        'id' => '1',
+                        'time' => '2013-10-18 14:28:51',
+                    ),
+                    array(
+                        'id' => '2',
+                        'time' => '2013-10-18 14:28:51',
+                    ),
+                    array(
+                        'id' => '3',
+                        'time' => '2013-10-18 14:28:51',
+                    ),
+                    array(
+                        'id' => '4',
+                        'time' => '2013-10-18 14:28:51',
+                    ),
+                    array(
+                        'id' => '5',
+                        'time' => '2013-10-18 14:28:51',
+                    ),
+                ),
+            ),
+            'entries_5_namespace' => array(
+                'content' => $this->readStubFile(static::$testStubsDir . '/seed_5_namespace.stub'),
+                'namespace' => 'App\Seeds',
                 'data' => array(
                     array(
                         'id' => '1',
@@ -63,6 +91,7 @@ class IseedTest extends PHPUnit_Framework_TestCase
             ),
             'entries_505' => array(
                 'content' => $this->readStubFile(static::$testStubsDir . '/seed_505.stub'),
+                'namespace' => null,
                 'data' => array(
                     array(
                         'id' => '1',
@@ -2088,7 +2117,7 @@ class IseedTest extends PHPUnit_Framework_TestCase
 
         $iSeed = new Orangehill\Iseed\Iseed();
         foreach ($testStubs as $key => $stub) {
-            $output = $iSeed->populateStub('test_class', $productionStub, 'test_table', $stub['data'], 500);
+            $output = $iSeed->populateStub('test_class', $productionStub, 'test_table', $stub['data'], 500, null, null, true, $stub['namespace']);
             $this->assertEquals($stub['content'], $output, "Stub {$key} is not what it's expected to be.");
         }
 

--- a/tests/Stubs/seed_5_namespace.stub
+++ b/tests/Stubs/seed_5_namespace.stub
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Seeds;
+
+use Illuminate\Database\Seeder;
+
+class test_class extends Seeder
+{
+
+    /**
+     * Auto generated seed file
+     *
+     * @return void
+     */
+    public function run()
+    {
+        
+
+        \DB::table('test_table')->delete();
+        
+        \DB::table('test_table')->insert(array (
+            0 => 
+            array (
+                'id' => '1',
+                'time' => '2013-10-18 14:28:51',
+            ),
+            1 => 
+            array (
+                'id' => '2',
+                'time' => '2013-10-18 14:28:51',
+            ),
+            2 => 
+            array (
+                'id' => '3',
+                'time' => '2013-10-18 14:28:51',
+            ),
+            3 => 
+            array (
+                'id' => '4',
+                'time' => '2013-10-18 14:28:51',
+            ),
+            4 => 
+            array (
+                'id' => '5',
+                'time' => '2013-10-18 14:28:51',
+            ),
+        ));
+        
+        
+    }
+}


### PR DESCRIPTION
Some projects could need to specify the namespace of the seeders created.

This will allow us to avoid some collision of class names.