### PR TITLE
Resolves issue #58 in a cross-platform friendly way per suggestion by @eduardodgarciac

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you wish to install it on Laravel 4 you should require `1.1` version:
 ## Artisan command options
 
 ### [table_name]
-Mandatory parameter which defines which table/s will be used for seed creation.
+Optional parameter which defines which table/s will be used for seed creation.
 Use CSV notation for multiple tables. Seed file will be generated for each table.
 
 Examples:
@@ -50,6 +50,11 @@ php artisan iseed my_table
 ```
 ```
 php artisan iseed my_table,another_table
+```
+
+If excluded, seed files will be generated for all tables in the database, except the migrations table.
+```
+php artisan iseed
 ```
 
 ### force

--- a/src/Orangehill/Iseed/IseedCommand.php
+++ b/src/Orangehill/Iseed/IseedCommand.php
@@ -54,7 +54,16 @@ class IseedCommand extends Command
             app('iseed')->cleanSection();
         }
 
-        $tables = explode(",", $this->argument('tables'));
+        $tables = array_filter(explode(",", $this->argument('tables')));
+
+        if (empty($tables)) {
+            $tables = \Schema::getConnection()->getDoctrineSchemaManager()->listTableNames();
+
+            if (($key = array_search('migrations', $tables)) !== false) {
+                unset($tables[$key]);
+            }
+        }
+
         $chunkSize = intval($this->option('max'));
         $exclude = explode(",", $this->option('exclude'));
         $prerunEvents = explode(",", $this->option('prerun'));
@@ -133,7 +142,7 @@ class IseedCommand extends Command
     protected function getArguments()
     {
         return array(
-            array('tables', InputArgument::REQUIRED, 'comma separated string of table names'),
+            array('tables', InputArgument::OPTIONAL, 'comma separated string of table names'),
         );
     }
 


### PR DESCRIPTION
Uses Doctrine's listTableNames() to generate the appropriate SQL for the platform when determining table names. Excludes migrations (because there's no reason to seed that) and updates the documentation with new usage instructions.