### PR TITLE
Add classnameprefix and classnamesuffix parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ For Laravel 5 installation edit your project's `composer.json` file to require `
     "require": {
 		"orangehill/iseed": "dev-master"
 	}
-	
+
 #### Laravel 5 versions less than 5.3.8
 For Laravel 5 versions that are less than 5.3.8 edit your project's `composer.json` file to require `2.2` version:
 
     "require": {
 		"orangehill/iseed": "2.2"
 	}
-	
+
 #### Laravel 4
 If you wish to install it on Laravel 4 you should require `1.1` version:
 
@@ -51,6 +51,32 @@ php artisan iseed my_table
 ```
 php artisan iseed my_table,another_table
 ```
+
+### classnameprefix & classnamesuffix
+Optionally specify a prefix or suffix for the Seeder class name and file name.
+This is useful if you want to create an additional seed for a table that has an existing seed without overwriting the existing.
+
+Examples:
+
+```
+php artisan iseed my_table --classnameprefix=Customized
+```
+outputs CustomizedMyTableSeeder.php
+
+```
+php artisan iseed my_table,another_table --classnameprefix=Customized
+```
+outputs CustomizedMyTableSeeder.php and CustomizedAnotherTableSeeder.php
+
+```
+php artisan iseed my_table --classnamesuffix=Customizations
+```
+outputs MyTableCustomizationsSeeder.php
+
+```
+php artisan iseed my_table,another_table --classnamesuffix=Customizations
+```
+outputs MyTableCustomizationsSeeder.php and AnotherTableCustomizationsSeeder.php
 
 ### force
 Optional parameter which is used to automatically overwrite any existing seeds for desired tables
@@ -149,7 +175,7 @@ artisan iseed users --noindex
 
 ## Usage
 
-To generate a seed file for your users table simply call: `\Iseed::generateSeed('users', 'connectionName', 'numOfRows');`. `connectionName` and `numOfRows` are not required arguments. 
+To generate a seed file for your users table simply call: `\Iseed::generateSeed('users', 'connectionName', 'numOfRows');`. `connectionName` and `numOfRows` are not required arguments.
 
 This will create a file inside a `/database/seeds` (`/app/database/seeds` for Laravel 4), with the contents similar to following example:
 
@@ -207,9 +233,9 @@ This will create a file inside a `/database/seeds` (`/app/database/seeds` for La
 
 	}
 
-This command will also update `/database/seeds/DatabaseSeeder.php` (`/app/database/seeds/DatabaseSeeder.php` for Laravel 4) to include a call to this newly generated seed class. 
+This command will also update `/database/seeds/DatabaseSeeder.php` (`/app/database/seeds/DatabaseSeeder.php` for Laravel 4) to include a call to this newly generated seed class.
 
-If you wish you can define custom iSeed template in which all the calls will be placed. You can do this by using `#iseed_start` and `#iseed_end` templates anywhere  within `/database/seeds/DatabaseSeeder.php` (`/app/database/seeds/DatabaseSeeder.php` for Laravel 4), for example: 
+If you wish you can define custom iSeed template in which all the calls will be placed. You can do this by using `#iseed_start` and `#iseed_end` templates anywhere  within `/database/seeds/DatabaseSeeder.php` (`/app/database/seeds/DatabaseSeeder.php` for Laravel 4), for example:
 
 	<?php
 
@@ -229,10 +255,10 @@ If you wish you can define custom iSeed template in which all the calls will be 
 		    {
 		        throw new \Exception('Only run this from production');
 		    }
-			
+
 			#iseed_start
-			
-			// here all the calls for newly generated seeds will be stored. 
+
+			// here all the calls for newly generated seeds will be stored.
 
 			#iseed_end
 		}
@@ -245,9 +271,9 @@ In case you try to generate seed file that already exists command will ask you a
 
 If you wish to clear iSeed template you can use Artisan Command Option `--clean`, e.g. `php artisan iseed users --clean`. This will clean template from `app/database/seeds/DatabaseSeeder.php` before creating new seed class.
 
-You can specify db connection that will be used for creation of new seed files by using Artisan Command Option `--database=connection_name`, e.g. `php artisan iseed users --database=mysql2`. 
+You can specify db connection that will be used for creation of new seed files by using Artisan Command Option `--database=connection_name`, e.g. `php artisan iseed users --database=mysql2`.
 
-To limit number of rows that will be exported from table use Artisan Command Option `--max=number_of_rows`, e.g. `php artisan iseed users --max=10`. If you use this option while exporting multiple tables specified limit will be applied to all of them.  
+To limit number of rows that will be exported from table use Artisan Command Option `--max=number_of_rows`, e.g. `php artisan iseed users --max=10`. If you use this option while exporting multiple tables specified limit will be applied to all of them.
 
 To (re)seed the database go to the Terminal and run Laravel's `db:seed command` (`php artisan db:seed`).
 

--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -52,6 +52,8 @@ class Iseed
     /**
      * Generates a seed file.
      * @param  string   $table
+     * @param  string   $prefix
+     * @param  string   $suffix
      * @param  string   $database
      * @param  int      $max
      * @param  string   $prerunEvent
@@ -59,7 +61,7 @@ class Iseed
      * @return bool
      * @throws Orangehill\Iseed\TableNotFoundException
      */
-    public function generateSeed($table, $database = null, $max = 0, $exclude = null, $prerunEvent = null, $postrunEvent = null, $dumpAuto = true, $indexed = true, $orderBy = null, $direction = 'ASC')
+    public function generateSeed($table, $prefix=null, $suffix=null, $database = null, $max = 0, $exclude = null, $prerunEvent = null, $postrunEvent = null, $dumpAuto = true, $indexed = true, $orderBy = null, $direction = 'ASC')
     {
         if (!$database) {
             $database = config('database.default');
@@ -79,7 +81,7 @@ class Iseed
         $dataArray = $this->repackSeedData($data);
 
         // Generate class name
-        $className = $this->generateClassName($table);
+        $className = $this->generateClassName($table, $prefix, $suffix);
 
         // Get template for a seed file contents
         $stub = $this->readStubFile($this->getStubPath() . '/seed.stub');
@@ -184,16 +186,18 @@ class Iseed
     /**
      * Generates a seed class name (also used as a filename)
      * @param  string  $table
+     * @param  string  $prefix
+     * @param  string  $suffix
      * @return string
      */
-    public function generateClassName($table)
+    public function generateClassName($table, $prefix=null, $suffix=null)
     {
         $tableString = '';
         $tableName = explode('_', $table);
         foreach ($tableName as $tableNameExploded) {
             $tableString .= ucfirst($tableNameExploded);
         }
-        return ucfirst($tableString) . 'TableSeeder';
+        return ($prefix ? $prefix : '') . ucfirst($tableString) . 'Table' . ($suffix ? $suffix : '') . 'Seeder';
     }
 
     /**

--- a/src/Orangehill/Iseed/IseedCommand.php
+++ b/src/Orangehill/Iseed/IseedCommand.php
@@ -63,6 +63,8 @@ class IseedCommand extends Command
         $indexed = !$this->option('noindex');
         $orderBy = $this->option('orderby');
         $direction = $this->option('direction');
+        $prefix = $this->option('classnameprefix');
+        $suffix = $this->option('classnamesuffix');
 
         if ($chunkSize < 1) {
             $chunkSize = null;
@@ -82,13 +84,15 @@ class IseedCommand extends Command
             $tableIncrement++;
 
             // generate file and class name based on name of the table
-            list($fileName, $className) = $this->generateFileName($table);
+            list($fileName, $className) = $this->generateFileName($table, $prefix, $suffix);
 
             // if file does not exist or force option is turned on generate seeder
             if (!\File::exists($fileName) || $this->option('force')) {
                 $this->printResult(
                     app('iseed')->generateSeed(
                         $table,
+                        $prefix,
+                        $suffix,
                         $this->option('database'),
                         $chunkSize,
                         $exclude,
@@ -109,6 +113,8 @@ class IseedCommand extends Command
                 $this->printResult(
                     app('iseed')->generateSeed(
                         $table,
+                        $prefix,
+                        $suffix,
                         $this->option('database'),
                         $chunkSize,
                         $exclude,
@@ -156,6 +162,8 @@ class IseedCommand extends Command
             array('noindex', null, InputOption::VALUE_NONE, 'no indexing in the seed', null),
             array('orderby', null, InputOption::VALUE_OPTIONAL, 'orderby desc by column', null),
             array('direction', null, InputOption::VALUE_OPTIONAL, 'orderby direction', null),
+            array('classnameprefix', null, InputOption::VALUE_OPTIONAL, 'prefix for class and file name', null),
+            array('classnamesuffix', null, InputOption::VALUE_OPTIONAL, 'suffix for class and file name', null),
         );
     }
 
@@ -182,14 +190,14 @@ class IseedCommand extends Command
      * @param  string $table
      * @return string
      */
-    protected function generateFileName($table)
+    protected function generateFileName($table, $prefix=null, $suffix=null)
     {
         if (!\Schema::connection($this->option('database') ? $this->option('database') : config('database.default'))->hasTable($table)) {
             throw new TableNotFoundException("Table $table was not found.");
         }
 
         // Generate class name and file name
-        $className = app('iseed')->generateClassName($table);
+        $className = app('iseed')->generateClassName($table, $prefix, $suffix);
         $seedPath = base_path() . config('iseed::config.path');
         return [$seedPath . '/' . $className . '.php', $className . '.php'];
     }

--- a/tests/IseedTest.php
+++ b/tests/IseedTest.php
@@ -2102,7 +2102,7 @@ class IseedTest extends PHPUnit_Framework_TestCase
     {
         $hasTable = m::mock('Orangehill\Iseed\Iseed[hasTable]')->makePartial();
         $hasTable->shouldReceive('hasTable')->once()->andReturn(false);
-        $hasTable->generateSeed('nonexisting', 'database', 'numOfRows');
+        $hasTable->generateSeed('nonexisting', null, null, 'database', 'numOfRows');
     }
 
     public function testRepacksSeedData()
@@ -2150,6 +2150,6 @@ class IseedTest extends PHPUnit_Framework_TestCase
         $mocked->shouldReceive('populateStub')->once()->andReturn('populatedStub');
         $mocked->shouldReceive('updateDatabaseSeederRunMethod')->once()->with('ClassName')->andReturn(true);
         $composer->shouldReceive('dumpAutoloads')->once();
-        $mocked->generateSeed('tablename', 'database', 'numOfRows');
+        $mocked->generateSeed('tablename', null, null, 'database', 'numOfRows');
     }
 }


### PR DESCRIPTION
I added `classnameprefix` and `classnamesuffix` options. Suffix seemed important so that filenames can remain alphabetically grouped (MyTableSeeder.php and MyTableCustomized.php vs MyTableSeeder.php and CustomizedMyTableSeeder.php).

Looks like my text editor stripped out some whitespace on the readme.md as well - hope that's not annoying.