### PR TITLE
new configuration options: custom seed.stub, custom seeder name/location, custom insert command

### DIFF
--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -84,7 +84,7 @@ class Iseed
         $className = $this->generateClassName($table, $prefix, $suffix);
 
         // Get template for a seed file contents
-        $stub = $this->readStubFile($this->getStubPath() . '/seed.stub');
+        $stub = $this->readStubFile(config('iseed.stub_path', $this->getStubPath() . '/seed.stub'));
 
         // Get a seed folder path
         $seedPath = $this->getSeedPath();
@@ -230,7 +230,7 @@ class Iseed
             $this->addNewLines($inserts);
             $this->addIndent($inserts, 2);
             $inserts .= sprintf(
-                "\DB::table('%s')->insert(%s);",
+                config('iseed.insert_command', "\DB::table('%s')->insert(%s);"),
                 $table,
                 $this->prettifyArray($chunk, $indexed)
             );
@@ -380,7 +380,8 @@ class Iseed
      */
     public function cleanSection()
     {
-        $databaseSeederPath = base_path() . config('iseed::config.path') . '/DatabaseSeeder.php';
+        $path = (config('iseed::config.seeder_path') ? config('iseed::config.seeder_path') : config('iseed::config.path') . '/DatabaseSeeder.php');
+        $databaseSeederPath = base_path() . $path;
 
         $content = $this->files->get($databaseSeederPath);
 
@@ -397,7 +398,12 @@ class Iseed
      */
     public function updateDatabaseSeederRunMethod($className)
     {
-        $databaseSeederPath = base_path() . config('iseed::config.path') . '/DatabaseSeeder.php';
+        if(config('iseed.seeder_modification') === false) {
+            return true;
+        }
+
+        $path = (config('iseed::config.seeder_path') ? config('iseed::config.seeder_path') : config('iseed::config.path') . '/DatabaseSeeder.php');
+        $databaseSeederPath = base_path() . $path;
 
         $content = $this->files->get($databaseSeederPath);
         if (strpos($content, "\$this->call({$className}::class)") === false) {

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,5 +1,38 @@
 <?php
-return array(
+return [
+    /**
+     * Path where the seeders will be generated
+     * The default is /database/seeds
+     */
     'path' => '/database/seeds',
-    'chunk_size' => 500 // Maximum number of rows per insert statement
-);
+
+    /**
+     * Path where the Seeder is
+     * The default is /database/seeds/DatabaseSeeder.php
+     */
+    'seeder_path' => '/database/seeds/DatabaseSeeder.php',
+
+    /**
+     * Whether the Seeder should be modified after running the iseed command
+     * The default is true
+     */
+    'seeder_modification' => true,
+
+    /**
+     * Maximum number of rows per insert statement
+     */
+    'chunk_size' => 500,
+
+    /**
+     * You may alternatively set an absolute path to a custom stub file
+     * The default stub file is located in /vendor/orangehill/iseed/src/Orangehill/Iseed/Stubs/seed.stub
+     */
+    'stub_path' => false,
+
+    /**
+     * You may customize the line that preceeds the inserts inside the seeder
+     * You MUST keep both %s however, the first will be replaced by the table name and the second by the inserts themselves
+     * The default is \DB::table('%s')->insert(%s);
+     */
+    'insert_command' => "\DB::table('%s')->insert(%s)",
+];


### PR DESCRIPTION
I added the following configuration options to make the package more flexible:

The ability to set your own seed.stub path
The ability to set the path of your Seeder file (including the name)
The ability to skip having the Seeder be modified after generation of the seed(s)
The ability to customize the Insert command