### PR TITLE
Add skip option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,24 @@ Example:
 php artisan iseed users --noindex
 ```
 
+### skip
+By using --skip the query will skip the number of rows provided.
+
+The use case for this feature is when you need to generate seeds while also using the --max option to limit the query.
+
+Example:
+```
+php artisan iseed blog_posts --skip=1000
+```
+
+When using with the --max option:
+
+```
+php artisan iseed blog_posts --max=1000
+php artisan iseed blog_posts --skip=1000 --max=1000
+php artisan iseed blog_posts --skip=2000 --max=1000
+```
+
 ## Usage
 
 To generate a seed file for your users table simply call: `\Iseed::generateSeed('users', 'connectionName', 'numOfRows');`. `connectionName` and `numOfRows` are not required arguments.

--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -61,7 +61,7 @@ class Iseed
      * @return bool
      * @throws Orangehill\Iseed\TableNotFoundException
      */
-    public function generateSeed($table, $prefix=null, $suffix=null, $database = null, $max = 0, $chunkSize = 0, $exclude = null, $prerunEvent = null, $postrunEvent = null, $dumpAuto = true, $indexed = true, $orderBy = null, $direction = 'ASC')
+    public function generateSeed($table, $prefix=null, $suffix=null, $database = null, $max = 0, $chunkSize = 0, $exclude = null, $prerunEvent = null, $postrunEvent = null, $dumpAuto = true, $indexed = true, $orderBy = null, $direction = 'ASC', $skip = null)
     {
         if (!$database) {
             $database = config('database.default');
@@ -75,7 +75,7 @@ class Iseed
         }
 
         // Get the data
-        $data = $this->getData($table, $max, $exclude, $orderBy, $direction);
+        $data = $this->getData($table, $max, $exclude, $orderBy, $direction, $skip);
 
         // Repack the data
         $dataArray = $this->repackSeedData($data);
@@ -130,13 +130,17 @@ class Iseed
      * @param  string $table
      * @return Array
      */
-    public function getData($table, $max, $exclude = null, $orderBy = null, $direction = 'ASC')
+    public function getData($table, $max, $exclude = null, $orderBy = null, $direction = 'ASC', $skip = null)
     {
         $result = \DB::connection($this->databaseName)->table($table);
 
         if (!empty($exclude)) {
             $allColumns = \DB::connection($this->databaseName)->getSchemaBuilder()->getColumnListing($table);
             $result = $result->select(array_diff($allColumns, $exclude));
+        }
+
+        if($skip) {
+            $result = $result->skip($skip);
         }
 
         if($orderBy) {

--- a/src/Orangehill/Iseed/IseedCommand.php
+++ b/src/Orangehill/Iseed/IseedCommand.php
@@ -66,6 +66,7 @@ class IseedCommand extends Command
         $direction = $this->option('direction');
         $prefix = $this->option('classnameprefix');
         $suffix = $this->option('classnamesuffix');
+        $skip = $this->option('skip');
 
         if ($max < 1) {
             $max = null;
@@ -107,7 +108,8 @@ class IseedCommand extends Command
                         $dumpAuto,
                         $indexed,
                         $orderBy,
-                        $direction
+                        $direction,
+                        $skip
                     ),
                     $table
                 );
@@ -128,7 +130,10 @@ class IseedCommand extends Command
                         $prerunEvent,
                         $postrunEvent,
                         $dumpAuto,
-                        $indexed
+                        $indexed,
+                        $orderBy,
+                        $direction,
+                        $skip
                     ),
                     $table
                 );
@@ -172,6 +177,7 @@ class IseedCommand extends Command
             array('direction', null, InputOption::VALUE_OPTIONAL, 'orderby direction', null),
             array('classnameprefix', null, InputOption::VALUE_OPTIONAL, 'prefix for class and file name', null),
             array('classnamesuffix', null, InputOption::VALUE_OPTIONAL, 'suffix for class and file name', null),
+            array('skip', null, InputOption::VALUE_OPTIONAL, 'number of rows to skip initially', null),
         );
     }
 


### PR DESCRIPTION
Was working with some big data (12,000 rows) and needed a way to skip past entries after using the current `max` option. 

Nothing crazy, I just added a new parameter to the seed function for `$skip`, and add a conditional to run a `->skip()` method on the query if it's detected. 

The only odd thing that **might be a breaking change** is the addition of `$direction` and `$orderBy` to the secondary generateSeed function (that runs after override confirmation). It didn't have those two params for some reason, and rather than just passing `null` to each, I tossed in the variables (cause I figured it can't hurt?).

Here's the command with the new option:

`php artisan iseed table_name --skip=1000`

And an example of it in use with --max:

```
php artisan iseed blog_posts --max=1000
php artisan iseed blog_posts --skip=1000 --max=1000
php artisan iseed blog_posts --skip=2000 --max=1000
```