### PR TITLE
key checks option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ Example:
 php artisan iseed users --noindex
 ```
 
+### keychecks
+By using --keychekcs the seed can be generated with `FOREIGN_KEY_CHECKS`.
+The use case for this feature is when you have an exisiting data in a table then you can run your seeder without truncating your tables. If you generate your seeds without truncating your database it might throw `foreign key constraint failed exception`. So, by using `--keychecks` option you can directly seed without the constraint error. On default, foreign key checks are disabled.
+
+Example:
+```
+php artisan iseed users --noindex
+```
+
 ## Usage
 
 To generate a seed file for your users table simply call: `\Iseed::generateSeed('users', 'connectionName', 'numOfRows');`. `connectionName` and `numOfRows` are not required arguments.

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ php artisan iseed users --noindex
 ```
 
 ### keychecks
-By using --keychekcs the seed can be generated with `FOREIGN_KEY_CHECKS`.
-The use case for this feature is when you have an exisiting data in a table then you can run your seeder without truncating your tables. If you generate your seeds without truncating your database it might throw `foreign key constraint failed exception`. So, by using `--keychecks` option you can directly seed without the constraint error. On default, foreign key checks are disabled.
+By using --keychecks the seeds can be generated with `FOREIGN_KEY_CHECKS` disabled and enabled.
+The use case for this feature is when you have an exisiting data in a table then you can run your seeds without having to truncate your tables. Without it, generating your seeds in an existing table with foreign keys might throw an error as `foreign key constraint failed`. So, by using `--keychecks` option you can directly seed without the constraint error. On default, foreign key checks are disabled.
 
 Example:
 ```
-php artisan iseed users --noindex
+php artisan iseed users --keychecks
 ```
 
 ## Usage

--- a/src/Orangehill/Iseed/IseedCommand.php
+++ b/src/Orangehill/Iseed/IseedCommand.php
@@ -66,7 +66,7 @@ class IseedCommand extends Command
         $direction = $this->option('direction');
         $prefix = $this->option('classnameprefix');
         $suffix = $this->option('classnamesuffix');
-
+        $keychecks = $this->option('keychecks');
         if ($max < 1) {
             $max = null;
         }
@@ -106,8 +106,9 @@ class IseedCommand extends Command
                         $postrunEvent,
                         $dumpAuto,
                         $indexed,
+                        $keychecks,
                         $orderBy,
-                        $direction
+                        $direction,
                     ),
                     $table
                 );
@@ -128,7 +129,8 @@ class IseedCommand extends Command
                         $prerunEvent,
                         $postrunEvent,
                         $dumpAuto,
-                        $indexed
+                        $indexed,
+                        $keychecks
                     ),
                     $table
                 );
@@ -172,6 +174,7 @@ class IseedCommand extends Command
             array('direction', null, InputOption::VALUE_OPTIONAL, 'orderby direction', null),
             array('classnameprefix', null, InputOption::VALUE_OPTIONAL, 'prefix for class and file name', null),
             array('classnamesuffix', null, InputOption::VALUE_OPTIONAL, 'suffix for class and file name', null),
+            array('keychecks', null, InputOption::VALUE_NONE, 'enable disable foreign keys checks', null),
         );
     }
 

--- a/src/Orangehill/Iseed/Stubs/seed.stub
+++ b/src/Orangehill/Iseed/Stubs/seed.stub
@@ -14,7 +14,10 @@ class {{class}} extends Seeder
     {
         {{prerun_event}}
 
+        {{disable_key_checks}}
         \DB::table('{{table}}')->delete();
+        {{enable_key_checks}}
+
         {{insert_statements}}
         
         {{postrun_event}}


### PR DESCRIPTION
I have no idea if there is another workaround.
Even if I arrange the seeders on proper order but running on an tables with data throws `foreign key constraint error` because of  `\DB::table('{{table}}')->delete();` . So, it would be great if we can run the updated seeds directly without having to truncating the table.