### PR TITLE
Qualifier is unnecessary and can be removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ class UsersTableSeeder extends Seeder {
         */
     public function run()
     {
-        \DB::table('users')->truncate();
-        \DB::table('users')->insert(array (
+        DB::table('users')->truncate();
+        DB::table('users')->insert(array (
             0 =>
             array (
                 'id' => '1',

--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -230,7 +230,7 @@ class Iseed
             $this->addNewLines($inserts);
             $this->addIndent($inserts, 2);
             $inserts .= sprintf(
-                "\DB::table('%s')->insert(%s);",
+                "DB::table('%s')->insert(%s);",
                 $table,
                 $this->prettifyArray($chunk, $indexed)
             );

--- a/src/Orangehill/Iseed/Stubs/seed.stub
+++ b/src/Orangehill/Iseed/Stubs/seed.stub
@@ -14,7 +14,7 @@ class {{class}} extends Seeder
     {
         {{prerun_event}}
 
-        \DB::table('{{table}}')->delete();
+        DB::table('{{table}}')->delete();
         {{insert_statements}}
         
         {{postrun_event}}

--- a/tests/Stubs/seed.stub
+++ b/tests/Stubs/seed.stub
@@ -14,7 +14,7 @@ class test_class extends Seeder
     {
         {{prerun_event}}
 
-        \DB::table('test_table')->delete();
+        DB::table('test_table')->delete();
         {{insert_statements}}
 
         {{postrun_event}}

--- a/tests/Stubs/seed_5.stub
+++ b/tests/Stubs/seed_5.stub
@@ -14,9 +14,9 @@ class test_class extends Seeder
     {
         
 
-        \DB::table('test_table')->delete();
+        DB::table('test_table')->delete();
         
-        \DB::table('test_table')->insert(array (
+        DB::table('test_table')->insert(array (
             0 => 
             array (
                 'id' => '1',

--- a/tests/Stubs/seed_505.stub
+++ b/tests/Stubs/seed_505.stub
@@ -14,9 +14,9 @@ class test_class extends Seeder
     {
         
 
-        \DB::table('test_table')->delete();
+        DB::table('test_table')->delete();
         
-        \DB::table('test_table')->insert(array (
+        DB::table('test_table')->insert(array (
             0 => 
             array (
                 'id' => '1',
@@ -2518,7 +2518,7 @@ class test_class extends Seeder
                 'time' => '2013-10-18 14:31:24',
             ),
         ));
-        \DB::table('test_table')->insert(array (
+        DB::table('test_table')->insert(array (
             0 => 
             array (
                 'id' => '501',

--- a/tests/Stubs/seed_blank.stub
+++ b/tests/Stubs/seed_blank.stub
@@ -14,7 +14,7 @@ class test_class extends Seeder
     {
         
 
-        \DB::table('test_table')->delete();
+        DB::table('test_table')->delete();
         
         
         


### PR DESCRIPTION
There is no need to use slash in `\DB::table()` **PHPStorm** gives warning: _Qualifier is unnecessary and can be removed_

This pull request fixes this.