### PR TITLE
Changed function prettifyArray() to not left-trim database content

### DIFF
--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -310,8 +310,6 @@ class Iseed
         $inString = false;
         $tabCount = 3;
         for ($i = 1; $i < count($lines); $i++) {
-            $lines[$i] = ltrim($lines[$i]);
-
             //Check for closing bracket
             if (strpos($lines[$i], ')') !== false) {
                 $tabCount--;


### PR DESCRIPTION
For my use case I'm storing  YAML data in the database, so trimming it will invalidate the YAML data.