### PR TITLE
fix: When using the --database parameter, specify connection for the …

### DIFF
--- a/src/Orangehill/Iseed/stubs/seed.stub
+++ b/src/Orangehill/Iseed/stubs/seed.stub
@@ -15,10 +15,8 @@ class {{class}} extends Seeder
     public function run()
     {
         {{prerun_event}}
-
-        \DB::table('{{table}}')->delete();
+        {{table_deletion}}
         {{insert_statements}}
-        
         {{postrun_event}}
     }
 }


### PR DESCRIPTION
When using the --database parameter specify a connection different from the default one, seeder file didn't specifies the same connection, that might cause an unexpected error and would make **CRITICAL** mistake(if there's a table has same name in the default connection).
``` diff
/**
* @todo append records to exists table only instead of deleting table before seeding.
**/
- \DB::table('bar')->delete();
+ \DB::connection('foo')->table('bar')->delete();
-\DB::table('bar')->insert(array (
+\DB::connection('foo')->table('bar')->insert(array (
```