### PR TITLE
Allow where clause 

### DIFF
--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -141,7 +141,7 @@ class Iseed
             $result = $result->select(array_diff($allColumns, $exclude));
         }
         if ($where) {
-            $result = $result->where($where);
+            $result = $result->where($where, null, null, 'or');
         }
 
         if ($orderBy) {

--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -144,7 +144,6 @@ class Iseed
             $result = $result->where($where);
         }
 
-        dd($result->toSql());
         if ($orderBy) {
             $result = $result->orderBy($orderBy, $direction);
         }

--- a/src/Orangehill/Iseed/IseedCommand.php
+++ b/src/Orangehill/Iseed/IseedCommand.php
@@ -75,6 +75,9 @@ class IseedCommand extends Command
         if ($this->option('where') && !$where) {
             throw new LogicException('where clause json malformed');
         }
+        if ($where && count($tables) > 1) {
+            throw new LogicException('please specify only one table when using where clause');
+        }
 
         if ($max < 1) {
             $max = null;


### PR DESCRIPTION
example: 
artisan iseed users --where='{"id":23465465}'
artisan iseed users --where='[["id", "<", 3]]'
artisan iseed users --where='{"id":1111,"id":2222, "id":3333}' ; // only three records with or logic
the only one table should be used with the command otherwise an exception'd be thrown