### PR TITLE
Add missing property declaration to fix PHP 8.2 deprecation warning

### DIFF
--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -33,6 +33,11 @@ class Iseed
     private $indentCharacter = "    ";
 
     /**
+     * @var Filesystem
+     */
+    private $files;
+
+    /**
      * @var Composer
      */
     private $composer;


### PR DESCRIPTION
This PR aims to fix #231.

See [PHP documentation](https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties) for more context.