### PR TITLE
Fix void returns in IseedCommand

### DIFF
--- a/src/Orangehill/Iseed/IseedCommand.php
+++ b/src/Orangehill/Iseed/IseedCommand.php
@@ -39,7 +39,7 @@ class IseedCommand extends Command
      */
     public function handle()
     {
-        return $this->fire();
+        $this->fire();
     }
 
     /**
@@ -134,8 +134,6 @@ class IseedCommand extends Command
                 );
             }
         }
-
-        return;
     }
 
     /**


### PR DESCRIPTION
Remove two `return` statements.
