### PR TITLE
Option to update sequence for postgres in generated seed.

### DIFF
--- a/src/Orangehill/Iseed/IseedCommand.php
+++ b/src/Orangehill/Iseed/IseedCommand.php
@@ -66,6 +66,7 @@ class IseedCommand extends Command
         $direction = $this->option('direction');
         $prefix = $this->option('classnameprefix');
         $suffix = $this->option('classnamesuffix');
+        $addSequence = $this->option('addsequence');
 
         if ($max < 1) {
             $max = null;
@@ -106,6 +107,7 @@ class IseedCommand extends Command
                         $postrunEvent,
                         $dumpAuto,
                         $indexed,
+                        $addSequence,
                         $orderBy,
                         $direction
                     ),
@@ -128,7 +130,8 @@ class IseedCommand extends Command
                         $prerunEvent,
                         $postrunEvent,
                         $dumpAuto,
-                        $indexed
+                        $indexed,
+                        $addSequence
                     ),
                     $table
                 );
@@ -172,6 +175,7 @@ class IseedCommand extends Command
             array('direction', null, InputOption::VALUE_OPTIONAL, 'orderby direction', null),
             array('classnameprefix', null, InputOption::VALUE_OPTIONAL, 'prefix for class and file name', null),
             array('classnamesuffix', null, InputOption::VALUE_OPTIONAL, 'suffix for class and file name', null),
+            array('addsequence', null, InputOption::VALUE_NONE, 'Add sequence to seed file', null),
         );
     }
 

--- a/src/Orangehill/Iseed/stubs/seed.stub
+++ b/src/Orangehill/Iseed/stubs/seed.stub
@@ -20,5 +20,8 @@ class {{class}} extends Seeder
         {{insert_statements}}
         
         {{postrun_event}}
+
+		{{add_sequence}}
+
     }
 }


### PR DESCRIPTION
Seeding a postgres DB worked great, but the sequence(auto_increment) does not get updated.
`php artisan iseed <table> --addsequence` makes sure the sequence is correct after the seed is run.