### PR TITLE
refactor: use config() helper for database connection default

### DIFF
--- a/src/Orangehill/Iseed/IseedCommand.php
+++ b/src/Orangehill/Iseed/IseedCommand.php
@@ -165,7 +165,7 @@ class IseedCommand extends Command
         return array(
             array('clean', null, InputOption::VALUE_NONE, 'clean iseed section', null),
             array('force', null, InputOption::VALUE_NONE, 'force overwrite of all existing seed classes', null),
-            array('database', null, InputOption::VALUE_OPTIONAL, 'database connection', \Config::get('database.default')),
+            array('database', null, InputOption::VALUE_OPTIONAL, 'database connection', config('database.default')),
             array('max', null, InputOption::VALUE_OPTIONAL, 'max number of rows', null),
             array('chunksize', null, InputOption::VALUE_OPTIONAL, 'size of data chunks for each insert query', null),
             array('exclude', null, InputOption::VALUE_OPTIONAL, 'exclude columns', null),


### PR DESCRIPTION
`IseedCommand.php` was using `\Config`, however it only works when an alias is set.
Which causes the following error:
```php
Class "Config" not found
at vendor/orangehill/iseed/src/Orangehill/Iseed/IseedCommand.php:168
```

This PR changes that to the `config()` helper.
This also improves consistency, since the `config()` helper was already being used in the same file, e.g. [line 209](https://github.com/ChrisToxz/iseed/blob/e0beff24959ddee051a44f6cd5e89c67acd12f5d/src/Orangehill/Iseed/IseedCommand.php#L209)
