### PR TITLE
Fix fatal error in --prerun/--postrun event hooks (namespaced seeders)

### DIFF
--- a/src/Orangehill/Iseed/Iseed.php
+++ b/src/Orangehill/Iseed/Iseed.php
@@ -294,13 +294,13 @@ class Iseed
 
         $prerunEventInsert = '';
         if ($prerunEvent) {
-            $prerunEventInsert .= "\$response = Event::until(new $prerunEvent());";
+            $prerunEventInsert .= "\$response = \\Event::until(new \\$prerunEvent());";
             $this->addNewLines($prerunEventInsert);
             $this->addIndent($prerunEventInsert, 2);
             $prerunEventInsert .= 'if ($response === false) {';
             $this->addNewLines($prerunEventInsert);
             $this->addIndent($prerunEventInsert, 3);
-            $prerunEventInsert .= 'throw new Exception("Prerun event failed, seed wasn\'t executed!");';
+            $prerunEventInsert .= 'throw new \Exception("Prerun event failed, seed wasn\'t executed!");';
             $this->addNewLines($prerunEventInsert);
             $this->addIndent($prerunEventInsert, 2);
             $prerunEventInsert .= '}';
@@ -327,13 +327,13 @@ class Iseed
 
         $postrunEventInsert = '';
         if ($postrunEvent) {
-            $postrunEventInsert .= "\$response = Event::until(new $postrunEvent());";
+            $postrunEventInsert .= "\$response = \\Event::until(new \\$postrunEvent());";
             $this->addNewLines($postrunEventInsert);
             $this->addIndent($postrunEventInsert, 2);
             $postrunEventInsert .= 'if ($response === false) {';
             $this->addNewLines($postrunEventInsert);
             $this->addIndent($postrunEventInsert, 3);
-            $postrunEventInsert .= 'throw new Exception("Seed was executed but the postrun event failed!");';
+            $postrunEventInsert .= 'throw new \Exception("Seed was executed but the postrun event failed!");';
             $this->addNewLines($postrunEventInsert);
             $this->addIndent($postrunEventInsert, 2);
             $postrunEventInsert .= '}';

--- a/tests/IseedTest.php
+++ b/tests/IseedTest.php
@@ -2099,6 +2099,96 @@ class IseedTest extends TestCase
         return implode(PHP_EOL, $buffer);
     }
 
+    public function testPrerunPostrunEventsAreNamespaceSafe()
+    {
+        // The production stub declares `namespace Database\Seeders;`, so any
+        // injected `Event`/`Exception`/event-class reference must be fully
+        // qualified (leading backslash) or it resolves to a non-existent
+        // Database\Seeders\* class and fatals at runtime.
+        $productionStub = $this->readStubFile(
+            substr(__DIR__, 0, -5) . 'src' . DIRECTORY_SEPARATOR . 'Orangehill'
+            . DIRECTORY_SEPARATOR . 'Iseed' . DIRECTORY_SEPARATOR . 'stubs'
+            . DIRECTORY_SEPARATOR . 'seed.stub'
+        );
+
+        $iseed = new Orangehill\Iseed\Iseed();
+        $output = $iseed->populateStub(
+            'NamespaceSafeSeeder',
+            $productionStub,
+            'test_table',
+            [['id' => '1']],
+            500,
+            'App\\Events\\SomePrerunEvent',
+            'App\\Events\\SomePostrunEvent'
+        );
+
+        // Facades, the base Exception and the user event classes must all be
+        // rooted at the global namespace.
+        $this->assertStringContainsString('\Event::until(new \App\Events\SomePrerunEvent())', $output);
+        $this->assertStringContainsString('\Event::until(new \App\Events\SomePostrunEvent())', $output);
+        $this->assertStringContainsString('throw new \Exception(', $output);
+        $this->assertStringNotContainsString(' Event::until', $output);
+        $this->assertStringNotContainsString('new Exception(', $output);
+
+        // The generated file must be valid, namespace-resolvable PHP. Stub out
+        // the global Event facade so the body can be loaded without Laravel.
+        $eventShim = "<?php class Event { public static function until(\$e) { return true; } }\n";
+        $tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'iseed_ns_' . getmypid();
+        @mkdir($tmpDir, 0777, true);
+        $eventClassPath = $tmpDir . DIRECTORY_SEPARATOR . 'event_shim.php';
+        $eventFqcnDir = $tmpDir . DIRECTORY_SEPARATOR . 'App' . DIRECTORY_SEPARATOR . 'Events';
+        @mkdir($eventFqcnDir, 0777, true);
+        file_put_contents($eventClassPath, $eventShim);
+        file_put_contents(
+            $eventFqcnDir . DIRECTORY_SEPARATOR . 'events.php',
+            "<?php namespace App\\Events; class SomePrerunEvent {} class SomePostrunEvent {}\n"
+        );
+        $seederPath = $tmpDir . DIRECTORY_SEPARATOR . 'NamespaceSafeSeeder.php';
+        file_put_contents($seederPath, $output);
+
+        // `php -l` proves it parses; loading + invoking run() proves the
+        // namespaced class references actually resolve at runtime.
+        $lint = [];
+        exec('php -l ' . escapeshellarg($seederPath) . ' 2>&1', $lint, $lintCode);
+        $this->assertSame(0, $lintCode, "Generated seeder failed php -l:\n" . implode("\n", $lint));
+
+        // Provide the DB facade the stub uses, plus the Event shim + events,
+        // then load the seeder and run it. A namespace resolution bug would
+        // surface here as a fatal "Class not found".
+        $harness = $tmpDir . DIRECTORY_SEPARATOR . 'harness.php';
+        file_put_contents($harness, <<<PHP
+<?php
+namespace {
+    class DB {
+        public static function table(\$t) { return new class { function delete(){} function insert(\$d){} }; }
+    }
+}
+namespace Illuminate\Database { class Seeder {} }
+namespace {
+    require '$eventClassPath';
+    require '$eventFqcnDir/events.php';
+    require '$seederPath';
+    \$s = new \\Database\\Seeders\\NamespaceSafeSeeder();
+    \$s->run();
+    echo "RAN_OK";
+}
+PHP
+        );
+        $run = [];
+        exec('php ' . escapeshellarg($harness) . ' 2>&1', $run, $runCode);
+        $this->assertSame(0, $runCode, "Generated seeder fataled at runtime:\n" . implode("\n", $run));
+        $this->assertStringContainsString('RAN_OK', implode("\n", $run));
+
+        // cleanup
+        @unlink($seederPath);
+        @unlink($eventClassPath);
+        @unlink($harness);
+        @unlink($eventFqcnDir . DIRECTORY_SEPARATOR . 'events.php');
+        @rmdir($eventFqcnDir);
+        @rmdir($tmpDir . DIRECTORY_SEPARATOR . 'App');
+        @rmdir($tmpDir);
+    }
+
     public function testTableNotFoundException()
     {
         $this->expectException(\Orangehill\Iseed\TableNotFoundException::class);


### PR DESCRIPTION
## Problem

Seeders generated with `--prerun` / `--postrun` event hooks **fatal at runtime** with `Error: Class "Database\Seeders\Exception" not found` (and the same for `Event` and the user's event class).

The injected hook code uses unqualified class names:

```php
$response = Event::until(new App\Events\SomeEvent());
if ($response === false) {
    throw new Exception("Prerun event failed, seed wasn't executed!");
}
```

Since these are emitted **inside** the stub's `namespace Database\Seeders;`, PHP resolves them relative to that namespace (`Database\Seeders\Event`, `Database\Seeders\Exception`, `Database\Seeders\App\Events\SomeEvent`) — none of which exist — so the seeder fatals.

### Why it went unnoticed

This is a regression from commit `4599ed3` (Oct 2020), which added `namespace Database\Seeders;` to the seed stub but touched only the `.stub` files. The event-injection code dates from 2016, when seeders lived in the global namespace where `Event`/`Exception` resolved correctly. The combination of the namespaced stub **and** the rarely-used `--prerun`/`--postrun` options is uncommon enough that nobody hit it.

## Fix

Prefix the injected `Event` facade, base `Exception`, and the user-supplied event class with a leading backslash so they resolve from the global namespace — matching the already-correct `\DB::` calls in the same stub.

```diff
-$response = Event::until(new $prerunEvent());
+$response = \Event::until(new \$prerunEvent());
...
-throw new Exception("Prerun event failed, seed wasn't executed!");
+throw new \Exception("Prerun event failed, seed wasn't executed!");
```

## Tests

- Adds `testPrerunPostrunEventsAreNamespaceSafe`, which asserts the fully-qualified output **and** loads + executes the generated seeder to prove it no longer fatals. (Fails on the old code, passes on the fix.)
- Full suite green (7/7).

### Manual verification (Laravel 10.48.28, PHP 8.3, MySQL)

- Common path `iseed users` — generates, lints, `db:seed` runs. ✅
- Event path `iseed users --prerun='App\Events\SomePrerunEvent' --postrun='App\Events\SomePostrunEvent'` — emits `\Event::until(new \App\Events\SomePrerunEvent())`, lints, **runs without fatal**, both hooks fire. ✅